### PR TITLE
Confusing link to the old com.mongodb.RawDBObject

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,7 +408,7 @@
                 </li>
                 <li>
                   <p>Java: <a
-                    href="https://github.com/mongodb/mongo-java-driver/blob/master/src/main/org/bson/BSON.java">Official
+                    href="https://github.com/mongodb/mongo-java-driver/blob/master/src/main/org/bson">Official
                     MongoDB driver</a> or <a
                     href="https://github.com/michel-kraemer/bson4jackson">bson4jackson</a>
                   or <a href="http://github.com/kohanyirobert/ebson">ebson</a></p>


### PR DESCRIPTION
I've visited the bsonspec.org website yesterday to find a Java Implementation to read BSON files. The current link points to the source of the com.mongodb.RawDBObject class. I would guess that this class is deprecated . However I've tried out to use this class without seeing that under the org.bson is a ready to use Java BSON implementation. It would be nice if you could change this link to avoid that other website visitors get confused.
