### PR TITLE
implementations: update C library link to libbson.

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -15,7 +15,7 @@
               <h3>BSON Libraries</h3>
               <ul>
                 <li>
-                  <p><a href="http://github.com/mongodb/mongo-c-driver/tree/master/src/">C</a> or <a href="https://github.com/chergert/mongo-glib/tree/master/mongo-glib">C (GLib)</a></p>
+                  <p><a href="https://github.com/mongodb/libbson/tree/master/">C</a> or <a href="https://github.com/chergert/mongo-glib/tree/master/mongo-glib">C (GLib)</a></p>
                 </li>
                 <li>
                   <p>


### PR DESCRIPTION
Libbson and mongo-c-driver were split into two separate libraries. Let's
just go ahead and link to libbson directly.

Signed-off-by: Christian Hergert christian.hergert@mongodb.com
