### PR TITLE
Link to js-bson library instead of Node driver that uses it

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -64,7 +64,7 @@
                   <p>Lua: <a href="https://github.com/tcoram/bson-lua">bson-lua</a> (pure; work in progress) or <a href="https://github.com/cloudwu/lua-bson">lua-bson</a> (implemented in C)</p>
                 </li>
                 <li>
-                  <p>Node.js: <a href="https://github.com/mongodb/node-mongodb-native">node-mongodb-native</a> or <a href="https://github.com/marcello3d/node-buffalo">node-buffalo (standalone)</p>
+                  <p>Node.js: <a href="https://github.com/mongodb/js-bson">js-bson</a> or <a href="https://github.com/marcello3d/node-buffalo">node-buffalo (standalone)</p>
                 </li>
                 <li>
                   <p><a href="http://massd.github.io/bson/">OCaml: bson.ml</a></p>


### PR DESCRIPTION
Use a more direct link to the js-bson project itself instead of a driver that uses it.
