### PR TITLE
Clarify - 6 is Undefined value, defined by spec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -110,7 +110,7 @@ the <code>document</code> non-terminal.</p>
                     <td class="fix nt"></td>
                     <td class="fix op">|</td>
                     <td class="fix ex">"\x06" e_name</td>
-                    <td>Undefined &mdash; <em>Deprecated</em></td>
+                    <td>Undefined (value) &mdash; <em>Deprecated</em></td>
                   </tr>
                   <tr>
                     <td class="fix nt"></td>


### PR DESCRIPTION
Original wording could be read that \0x06 is not defined by the spec, rather than defined by the spec as an "undef" type value. This should make things more clear.