### PR TITLE
Fix typo in spec notes, hex capitalization consistency

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -291,7 +291,7 @@ the <code>document</code> non-terminal.</p>
 <ul>  
   <li>\x02 Binary (Old) - This used to be the default subtype, but was deprecated in favor of \x00. Drivers and tools should be sure to handle \x02 appropriately. The structure of the binary data (the byte* array in the binary non-terminal) must be an int32 followed by a (byte*). The int32 is the number of bytes in the repetition.</li>
   <li>\x03 UUID (Old) - This used to be the UUID subtype, but was deprecated in favor of \x04. Drivers and tools for languages with a native UUID type should handle \x03 appropriately.</li>
-  <li>\x80-0xff "User defined" subtypes. The binary data can be anything.</li>
+  <li>\x80-\xFF "User defined" subtypes. The binary data can be anything.</li>
 </ul>
 </li>
 <li >Code w/ scope - The int32 is the length in bytes of the entire code_w_s value. The string is JavaScript code. The document is a mapping from identifiers to values, representing the scope in which the string should be evaluated.</li>


### PR DESCRIPTION
Hex notation written as 0x instead of \x in Notes/BinData at the bottom of the page. Also, \xFF is written with lowercase, which is inconsistent with other hex in the page. DOCS-5559