### PR TITLE
Specify floating point format & minor capitalization

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -176,7 +176,7 @@ the <code>document</code> non-terminal.</p>
                     <td class="fix nt"></td>
                     <td class="fix op">|</td>
                     <td class="fix ex">"\x10" e_name int32</td>
-                    <td>32-bit Integer</td>
+                    <td>32-bit integer</td>
                   </tr>
                   <tr>
                     <td class="fix nt"></td>

--- a/spec.html
+++ b/spec.html
@@ -38,7 +38,7 @@ the <code>document</code> non-terminal.</p>
                   </tr>
                   <tr>
                     <td class="t">double</td>
-                    <td>8 bytes (64-bit IEEE 754 floating point)</td>
+                    <td>8 bytes (64-bit IEEE 754-2008 binary floating point)</td>
                   </tr>
                 </table>
               </div>
@@ -80,7 +80,7 @@ the <code>document</code> non-terminal.</p>
                     <td class="fix nt">element</td>
                     <td class="fix op">::=</td>
                     <td class="fix ex">"\x01" e_name double</td>
-                    <td>Floating point</td>
+                    <td>64-bit binary floating point</td>
                   </tr>
                   <tr>
                     <td class="fix nt"></td>


### PR DESCRIPTION
The latest IEEE-2008 spec features multiple kinds of floating point numbers, both binary and decimal. Specify that BSON Spec v1.0 supports the 64-bit binary floating point.