### PR TITLE
SPEC-759 BSON Spec should not limit regex modifiers

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -150,7 +150,7 @@ the <code>document</code> non-terminal.</p>
                     <td class="fix nt"></td>
                     <td class="fix op">|</td>
                     <td class="fix ex">"\x0B" e_name cstring cstring</td>
-                    <td >Regular expression - The first cstring is the regex pattern, the second is the regex options string. Options are identified by characters, which must be stored in alphabetical order. Valid options are 'i' for case insensitive matching, 'm' for multiline matching, 'x' for verbose mode, 'l' to make \w, \W, etc. locale dependent, 's' for dotall mode ('.' matches everything), and 'u' to make \w, \W, etc. match unicode.</td>
+                    <td >Regular expression - The first cstring is the regex pattern, the second is the regex options string.</td>
                   </tr>
                   <tr>
                     <td class="fix nt"></td>


### PR DESCRIPTION
No driver enforces alphabetical order, or the limitation of which characters are allowed.

It isn't up to BSON to dictate this, but the user of the type.

MongoDB documents the currently supported modifiers here:
https://docs.mongodb.com/manual/reference/operator/query/regex/