### PR TITLE
added note to JSON for Modern C++

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -58,6 +58,8 @@
             <li><p><a href="https://github.com/dwight/bson-cxx">github.com/dwight/bson-cxx</a> - Yet another C++ BSON
               implementation originating from the MongoDB C++ driver. Non-BSON code was eliminated, Endian-awareness
               was added, and some attempts were made to simplify the interface.</li>
+            <li><p><a href="https://github.com/nlohmann/json">JSON for Modern C++</a> - A library to make JSON a
+                first-class data type in C++ which can read and write a subset of BSON that can map to JSON.</li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
Since version 3.4.0, JSON for Modern C++ supports BSON.