### PR TITLE
Remove Ejdb.BSON

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -45,8 +45,6 @@
               - Included with the official MongoDB C#/.NET driver.</li>
             <li><p><a href="https://github.com/karlseguin/Metsys.Bson">Metsys.Bson</a>
               - A BSON serializer/deserializer for .NET.</li>
-            <li><p><a href="https://github.com/Softmotions/ejdb/tree/master/nejdb">Ejdb.BSON</a>
-              - Included with the EJDB C# .Net binding.</li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
It's added by https://github.com/mongodb/bsonspec.org/pull/17.
But according to https://github.com/Softmotions/ejdb-csharp, it seems to be no longer maintained.