### PR TITLE
Spell out BSON in binary in the logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
         <div id="graphic">
           <div id="right-brace" class="brace">}</div>
           <div id="bits">
-            01010100<br>
-            11101011<br>
-            10101110<br>
-            01010101
+            01000010<br>
+            01010011<br>
+            01001111<br>
+            01001110
           </div>
           <div id="left-brace" class="brace">{</div>
         </div>


### PR DESCRIPTION
If the binary in the logo was already intentionally spelling something else, forgive me, but it looked like it was spelling T�U (hex: 54 EF BF BD 55), which doesn't seem to mean anything. So I changed it to spell BSON, for a fun easter egg.