### PR TITLE
Updates links to Fantom libraries

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -124,10 +124,8 @@
         <li>
           <p>Fantom</p>
           <ul>
-              <li><p><a href="http://www.fantomfactory.org/pods/afBson">afBson</a>
+              <li><p><a href="https://eggbox.fantomfactory.org/pods/afBson">afBson</a>
                 - Implementation created to support the development of the afMongo driver for MongoDB.</li>
-              <li><p><a href="http://bitbucket.org/liamstask/fantomongo/src/tip/fan/bson/">Fantomongo driver</a>
-              - A pure Fantom driver for MongoDB.</li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
Updated link to Fantom's afBson, removed a dead link to an older, now non-existant, library.