### PR TITLE
Replaced abandoned Go driver with official one.

### DIFF
--- a/implementations.html
+++ b/implementations.html
@@ -141,7 +141,7 @@
           <ul>
               <li><p><a href="http://labix.org/gobson">gobson</a>
                 - BSON library implemented to support the mgo MongoDB driver for Go.</li>
-              <li><p><a href="https://github.com/mikejs/gomongo">gomongo</a> - Driver for MongoDB.</li>
+              <li><p><a href="https://github.com/mongodb/mongo-go-driver/">mongo-driver</a> - Official MongoDB Go driver.</li>
               <li><p><a href="https://github.com/mongodb/mongo-go-driver/tree/master/bson">bson</a> - BSON library implemented to support the offical MongoDB Go driver.</li>
           </ul>
         </li>

--- a/implementations.html
+++ b/implementations.html
@@ -142,7 +142,7 @@
               <li><p><a href="http://labix.org/gobson">gobson</a>
                 - BSON library implemented to support the mgo MongoDB driver for Go.</li>
               <li><p><a href="https://github.com/mongodb/mongo-go-driver/">mongo-driver</a> - Official MongoDB Go driver.</li>
-              <li><p><a href="https://github.com/mongodb/mongo-go-driver/tree/master/bson">bson</a> - BSON library implemented to support the offical MongoDB Go driver.</li>
+              <li><p><a href="https://github.com/mongodb/mongo-go-driver/tree/master/bson">bson</a> - BSON library implemented to support the official MongoDB Go driver.</li>
           </ul>
         </li>
         <li>

--- a/implementations.html
+++ b/implementations.html
@@ -139,10 +139,11 @@
         <li>
           <p>Go</p>
           <ul>
-              <li><p><a href="http://labix.org/gobson">gobson</a>
-                - BSON library implemented to support the mgo MongoDB driver for Go.</li>
-              <li><p><a href="https://github.com/mongodb/mongo-go-driver/">mongo-driver</a> - Official MongoDB Go driver.</li>
-              <li><p><a href="https://github.com/mongodb/mongo-go-driver/tree/master/bson">bson</a> - BSON library implemented to support the official MongoDB Go driver.</li>
+              <li><p><a href="https://github.com/mongodb/mongo-go-driver/">mongo-go-driver</a> - Official MongoDB Go driver.</li>
+              <li><p><a
+              href="https://github.com/mongodb/mongo-go-driver/tree/master/bson">bson</a>
+              - BSON library implemented within the official MongoDB Go
+              driver. See the <a href="https://www.mongodb.com/docs/drivers/go/current/fundamentals/bson/">documentation</a> to learn more.</li>
           </ul>
         </li>
         <li>


### PR DESCRIPTION
https://github.com/mikejs/gomongo hasn't seen a commit in over 12 years. We should be linking people to our official driver.