### PR TITLE
Improve non-terminal expression rendering

### DIFF
--- a/css/spec.css
+++ b/css/spec.css
@@ -7,10 +7,12 @@ td.fix {
     font-size: 123.1%;
     font-family: monospace;
     padding-right: 0.5em;
+    vertical-align: top;
 }
 td.op {
     text-align: right;
 }
 td.ex {
     width: 19em;
+    white-space: nowrap;
 }


### PR DESCRIPTION
After the nice improvements in #80, I noticed that the extra length in the non-terminal expressions was making them word-wrap more, which made them harder to read.  Adding `white-space: nowrap` to the CSS fixes the problem and makes them much easier to read.  I also took the opportunity to top-align all the expressions - the centre-alignment has always made things harder to read (eg. most noticeable for the regex type, where the start of the explanation is several lines above the spec line).  I think overall these are simple improvements that make the spec much easier to read.

BEFORE (Dark Reader enabled, sorry):
![image](https://github.com/mongodb/bsonspec.org/assets/1083020/ec9dcccf-7fdd-4ad8-b54c-d93b23681dc6)

AFTER:
![image](https://github.com/mongodb/bsonspec.org/assets/1083020/b094f61e-ecb4-44fe-acba-cbc13fd913d0)