### PR TITLE
DOCS-15103: type 7 (compressed column)

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -343,11 +343,10 @@
     <li>Max key - Special type which compares higher than all other possible BSON element values.</li>
     <li>Generic binary subtype - This is the most commonly used binary subtype and should be the 'default' for drivers
       and tools.</li>
-    <li>Compressed BSON Column - This data type permits compact storage
-      by using BSON type-specific delta or delta-of-delta compression
-      stored in Simple-8b blocks, which uses few bits per element. This
-      type also enables efficient encoding for sparse arrays containing
-      missing values.</li>
+    <li>Compressed BSON Column - Compact storage of BSON data. This data
+      type uses delta and delta-of-delta compression and
+      run-length-encoding for efficient element storage. Also has an
+      encoding for sparse arrays containing missing values.</li>
     <li>The BSON "binary" or "BinData" datatype is used to represent
       arrays of bytes. It is somewhat analogous to the Java notion of a
       ByteArray. BSON binary values have a <em>subtype</em>. This is used to

--- a/spec.html
+++ b/spec.html
@@ -343,6 +343,11 @@
     <li>Max key - Special type which compares higher than all other possible BSON element values.</li>
     <li>Generic binary subtype - This is the most commonly used binary subtype and should be the 'default' for drivers
       and tools.</li>
+    <li>Compressed BSON Column - This data type permits compact storage
+      by using BSON type-specific delta or delta-of-delta compression
+      stored in Simple-8b blocks, which uses few bits per element. This
+      type also enables efficient encoding for sparse arrays containing
+      missing values.</li>
     <li>The BSON "binary" or "BinData" datatype is used to represent
       arrays of bytes. It is somewhat analogous to the Java notion of a
       ByteArray. BSON binary values have a <em>subtype</em>. This is used to

--- a/spec.html
+++ b/spec.html
@@ -1,366 +1,383 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
 <html>
+
 <head>
-    <title>BSON (Binary JSON): Specification</title>
-    <link rel="stylesheet" href="css/spec.css" type="text/css">
+  <title>BSON (Binary JSON): Specification</title>
+  <link rel="stylesheet" href="css/spec.css" type="text/css">
 </head>
+
 <body>
-<h2 class="nojs">Specification Version 1.1</h2>
+  <h2 class="nojs">Specification Version 1.1</h2>
 
-<p>BSON is a binary format in which zero or more ordered key/value
-pairs are stored as a single entity. We call this entity
-a <em>document</em>.</p>
+  <p>BSON is a binary format in which zero or more ordered key/value
+    pairs are stored as a single entity. We call this entity
+    a <em>document</em>.</p>
 
-<p>The following grammar specifies version 1.1 of the
-BSON standard. We've written the grammar using a
-pseudo-<a href="http://en.wikipedia.org/wiki/Backus%E2%80%93Naur_Form">BNF</a>
-syntax. Valid BSON data is represented by
-the <code>document</code> non-terminal.</p>
+  <p>The following grammar specifies version 1.1 of the
+    BSON standard. We've written the grammar using a
+    pseudo-<a href="http://en.wikipedia.org/wiki/Backus%E2%80%93Naur_Form">BNF</a>
+    syntax. Valid BSON data is represented by
+    the <code>document</code> non-terminal.</p>
 
-<div id="grammar">
-              <h3>Basic Types</h3>
+  <div id="grammar">
+    <h3>Basic Types</h3>
 
-              <p>The following basic types are used as terminals in
-              the rest of the grammar. Each type must be serialized in
-              little-endian format.</p>
+    <p>The following basic types are used as terminals in
+      the rest of the grammar. Each type must be serialized in
+      little-endian format.</p>
 
-              <div class="tb">
-                <table>
-                  <tr>
-                    <td class="t">byte</td>
-                    <td>1 byte (8-bits)</td>
-                  </tr>
-                  <tr>
-                    <td class="t">signed_byte(n)</td>
-                    <td>8-bit, two's complement signed integer for which the value is <code>n</code></td>
-                  </tr>
-                  <tr>
-                    <td class="t">unsigned_byte(n)</td>
-                    <td>8-bit unsigned integer for which the value is <code>n</code></td>
-                  </tr>
-                  <tr>
-                    <td class="t">int32</td>
-                    <td>4 bytes (32-bit signed integer, two's complement)</td>
-                  </tr>
-                  <tr>
-                    <td class="t">int64</td>
-                    <td>8 bytes (64-bit signed integer, two's complement)</td>
-                  </tr>
-                  <tr>
-                    <td class="t">uint64</td>
-                    <td>8 bytes (64-bit unsigned integer)</td>
-                  </tr>
-                  <tr>
-                    <td class="t">double</td>
-                    <td>8 bytes (64-bit IEEE 754-2008 binary floating point)</td>
-                  </tr>
-                  <tr>
-                    <td class="t">decimal128</td>
-                    <td>16 bytes (128-bit IEEE 754-2008 decimal floating point)</td>
-                  </tr>
-                </table>
-              </div>
+    <div class="tb">
+      <table>
+        <tr>
+          <td class="t">byte</td>
+          <td>1 byte (8-bits)</td>
+        </tr>
+        <tr>
+          <td class="t">signed_byte(n)</td>
+          <td>8-bit, two's complement signed integer for which the value is <code>n</code></td>
+        </tr>
+        <tr>
+          <td class="t">unsigned_byte(n)</td>
+          <td>8-bit unsigned integer for which the value is <code>n</code></td>
+        </tr>
+        <tr>
+          <td class="t">int32</td>
+          <td>4 bytes (32-bit signed integer, two's complement)</td>
+        </tr>
+        <tr>
+          <td class="t">int64</td>
+          <td>8 bytes (64-bit signed integer, two's complement)</td>
+        </tr>
+        <tr>
+          <td class="t">uint64</td>
+          <td>8 bytes (64-bit unsigned integer)</td>
+        </tr>
+        <tr>
+          <td class="t">double</td>
+          <td>8 bytes (64-bit IEEE 754-2008 binary floating point)</td>
+        </tr>
+        <tr>
+          <td class="t">decimal128</td>
+          <td>16 bytes (128-bit IEEE 754-2008 decimal floating point)</td>
+        </tr>
+      </table>
+    </div>
 
-              <h3>Non-terminals</h3>
+    <h3>Non-terminals</h3>
 
-              <p>The following specifies the rest of the BSON
-              grammar. Note that we use the <code>*</code> operator as
-              shorthand for repetition (e.g. <code>(byte*2)</code>
-              is <code>byte byte</code>). When used as a unary
-              operator, <code>*</code> means that the repetition can
-              occur 0 or more times.</p>
+    <p>The following specifies the rest of the BSON
+      grammar. Note that we use the <code>*</code> operator as
+      shorthand for repetition (e.g. <code>(byte*2)</code>
+      is <code>byte byte</code>). When used as a unary
+      operator, <code>*</code> means that the repetition can
+      occur 0 or more times.</p>
 
-              <div class="tb">
-                <table>
-                  <tr>
-                    <td class="fix nt">document</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">int32 e_list unsigned_byte(0)</td>
-                    <td >BSON Document. int32 is the total number of bytes comprising the document.</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">e_list</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">element e_list</td>
-                    <td></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">""</td>
-                    <td></td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">element</td>
-                    <td class="fix op">::=</td>
-                    <td style="width:35%" class="fix ex">signed_byte(1) e_name double</td>
-                    <td>64-bit binary floating point</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(2) e_name string</td>
-                    <td>UTF-8 string</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(3) e_name document</td>
-                    <td>Embedded document</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(4) e_name document</td>
-                    <td >Array</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(5) e_name binary</td>
-                    <td>Binary data</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(6) e_name</td>
-                    <td>Undefined (value) &mdash; <em>Deprecated</em></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(7) e_name (byte*12)</td>
-                    <td><a href="https://www.mongodb.com/docs/manual/reference/bson-types/#objectid">ObjectId</a></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(8) e_name unsigned_byte(0)</td>
-                    <td>Boolean - false</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(8) e_name unsigned_byte(1)</td>
-                    <td>Boolean - true</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(9) e_name int64</td>
-                    <td >UTC datetime</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(10) e_name</td>
-                    <td>Null value</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(11) e_name cstring cstring</td>
-                    <td >Regular expression - The first cstring is the regex pattern, the second is the regex options string. Options are identified by characters, which must be stored in alphabetical order. Valid options are 'i' for case insensitive matching, 'm' for multiline matching, 'x' for verbose mode, 'l' to make \w, \W, etc. locale dependent, 's' for dotall mode ('.' matches everything), and 'u' to make \w, \W, etc. match unicode.</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(12) e_name string (byte*12)</td>
-                    <td>DBPointer &mdash; <em>Deprecated</em></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(13) e_name string</td>
-                    <td>JavaScript code</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(14) e_name string</td>
-                    <td> Symbol &mdash; <em>Deprecated</em></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(15) e_name code_w_s</td>
-                    <td>JavaScript code with scope &mdash; <em>Deprecated</em></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(16) e_name int32</td>
-                    <td>32-bit integer</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(17) e_name uint64</td>
-                    <td >Timestamp</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(18) e_name int64</td>
-                    <td>64-bit integer</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(19) e_name decimal128</td>
-                    <td><a href="https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst">128-bit decimal floating point</a></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(-1) e_name</td>
-                    <td >Min key</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">signed_byte(127) e_name</td>
-                    <td >Max key</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">e_name</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">cstring</td>
-                    <td>Key name</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">string</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">int32 (byte*) unsigned_byte(0)</td>
-                    <td >String - The int32 is the number bytes in the
-                    (byte*) plus one for the trailing null byte. The (byte*) is
-                    zero or more UTF-8 encoded characters.</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">cstring</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">(byte*) unsigned_byte(0)</td>
-                    <td >Zero or more modified UTF-8 encoded characters
-                    followed by the null byte. The (byte*) MUST NOT contain
-                    <code>unsigned_byte(0)</code>, hence it is not full UTF-8.</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">binary</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">int32 subtype (byte*)</td>
-                    <td >Binary - The int32 is the number of bytes in the (byte*).</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">subtype</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">unsigned_byte(0)</td>
-                    <td >Generic binary subtype</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(1)</td>
-                    <td>Function</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(2)</td>
-                    <td >Binary (Old)</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(3)</td>
-                    <td >UUID (Old)</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(4)</td>
-                    <td>UUID</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(5)</td>
-                    <td>MD5</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(6)</td>
-                    <td><a href="https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/subtype6.rst">Encrypted BSON value</a></td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(7)</td>
-                    <td>Compressed BSON column</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(8)</td>
-                    <td>Sensitive</td>
-                  </tr>
-                  <tr>
-                    <td class="fix nt"></td>
-                    <td class="fix op">|</td>
-                    <td class="fix ex">unsigned_byte(128)&mdash;unsigned_byte(255)</td>
-                    <td >User defined</td>
-                  </tr>
-                  <tr class="section">
-                    <td class="fix nt">code_w_s</td>
-                    <td class="fix op">::=</td>
-                    <td class="fix ex">int32 string document</td>
-                    <td >Code with scope &mdash; <em>Deprecated</em></td>
-                  </tr>
-                </table>
-              </div>
-</div>
+    <div class="tb">
+      <table>
+        <tr>
+          <td class="fix nt">document</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">int32 e_list unsigned_byte(0)</td>
+          <td>BSON Document. int32 is the total number of bytes comprising the document.</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">e_list</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">element e_list</td>
+          <td></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">""</td>
+          <td></td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">element</td>
+          <td class="fix op">::=</td>
+          <td style="width:35%" class="fix ex">signed_byte(1) e_name double</td>
+          <td>64-bit binary floating point</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(2) e_name string</td>
+          <td>UTF-8 string</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(3) e_name document</td>
+          <td>Embedded document</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(4) e_name document</td>
+          <td>Array</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(5) e_name binary</td>
+          <td>Binary data</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(6) e_name</td>
+          <td>Undefined (value) &mdash; <em>Deprecated</em></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(7) e_name (byte*12)</td>
+          <td><a href="https://www.mongodb.com/docs/manual/reference/bson-types/#objectid">ObjectId</a></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(8) e_name unsigned_byte(0)</td>
+          <td>Boolean - false</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(8) e_name unsigned_byte(1)</td>
+          <td>Boolean - true</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(9) e_name int64</td>
+          <td>UTC datetime</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(10) e_name</td>
+          <td>Null value</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(11) e_name cstring cstring</td>
+          <td>Regular expression - The first cstring is the regex pattern, the second is the regex options string.
+            Options are identified by characters, which must be stored in alphabetical order. Valid options are 'i' for
+            case insensitive matching, 'm' for multiline matching, 'x' for verbose mode, 'l' to make \w, \W, etc. locale
+            dependent, 's' for dotall mode ('.' matches everything), and 'u' to make \w, \W, etc. match unicode.</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(12) e_name string (byte*12)</td>
+          <td>DBPointer &mdash; <em>Deprecated</em></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(13) e_name string</td>
+          <td>JavaScript code</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(14) e_name string</td>
+          <td> Symbol &mdash; <em>Deprecated</em></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(15) e_name code_w_s</td>
+          <td>JavaScript code with scope &mdash; <em>Deprecated</em></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(16) e_name int32</td>
+          <td>32-bit integer</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(17) e_name uint64</td>
+          <td>Timestamp</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(18) e_name int64</td>
+          <td>64-bit integer</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(19) e_name decimal128</td>
+          <td><a
+              href="https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst">128-bit
+              decimal floating point</a></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(-1) e_name</td>
+          <td>Min key</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">signed_byte(127) e_name</td>
+          <td>Max key</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">e_name</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">cstring</td>
+          <td>Key name</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">string</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">int32 (byte*) unsigned_byte(0)</td>
+          <td>String - The int32 is the number bytes in the
+            (byte*) plus one for the trailing null byte. The (byte*) is
+            zero or more UTF-8 encoded characters.</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">cstring</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">(byte*) unsigned_byte(0)</td>
+          <td>Zero or more modified UTF-8 encoded characters
+            followed by the null byte. The (byte*) MUST NOT contain
+            <code>unsigned_byte(0)</code>, hence it is not full UTF-8.
+          </td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">binary</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">int32 subtype (byte*)</td>
+          <td>Binary - The int32 is the number of bytes in the (byte*).</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">subtype</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">unsigned_byte(0)</td>
+          <td>Generic binary subtype</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(1)</td>
+          <td>Function</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(2)</td>
+          <td>Binary (Old)</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(3)</td>
+          <td>UUID (Old)</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(4)</td>
+          <td>UUID</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(5)</td>
+          <td>MD5</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(6)</td>
+          <td><a
+              href="https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/subtype6.rst">Encrypted
+              BSON value</a></td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(7)</td>
+          <td>Compressed BSON column</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(8)</td>
+          <td>Sensitive</td>
+        </tr>
+        <tr>
+          <td class="fix nt"></td>
+          <td class="fix op">|</td>
+          <td class="fix ex">unsigned_byte(128)&mdash;unsigned_byte(255)</td>
+          <td>User defined</td>
+        </tr>
+        <tr class="section">
+          <td class="fix nt">code_w_s</td>
+          <td class="fix op">::=</td>
+          <td class="fix ex">int32 string document</td>
+          <td>Code with scope &mdash; <em>Deprecated</em></td>
+        </tr>
+      </table>
+    </div>
+  </div>
 
 
-<h3>Notes</h3>
-<ul>
-  <li>Array - The document for an array is a normal BSON document with integer values for the keys, starting with 0 and continuing sequentially. For example, the array ['red', 'blue'] would be encoded as the document {'0': 'red', '1': 'blue'}. The keys must be in ascending numerical order.</li>
-  <li>UTC datetime - The int64 is UTC milliseconds since the Unix epoch.</li>
-  <li>Timestamp - Special internal type used by MongoDB replication and sharding. First 4 bytes are an increment, second 4 are a timestamp.</li>
-  <li>Min key - Special type which compares lower than all other possible BSON element values.</li>
-  <li>Max key - Special type which compares higher than all other possible BSON element values.</li>
-  <li>Generic binary subtype - This is the most commonly used binary subtype and should be the 'default' for drivers and tools.</li>
-  <li>The BSON "binary" or "BinData" datatype is used to represent
-  arrays of bytes. It is somewhat analogous to the Java notion of a
-  ByteArray. BSON binary values have a <em>subtype</em>. This is used to
-  indicate what kind of data is in the byte array. Subtypes from 0 to
-  127 are predefined or reserved. Subtypes from 128 to 255 are
-  user-defined.
+  <h3>Notes</h3>
   <ul>
-    <li><code>unsigned_byte(2)</code> Binary (Old) - This used to be the default
-    subtype, but was deprecated in favor of subtype 0.
-    Drivers and tools should be sure to handle subtype 2
-    appropriately. The structure of the binary data (the byte* array in
-    the binary non-terminal) must be an int32 followed by a (byte*). The
-    int32 is the number of bytes in the repetition.</li>
-    <li><code>unsigned_byte(3)</code> UUID (Old) - This used to be the UUID subtype,
-    but was deprecated in favor of subtype 4. Drivers
-    and tools for languages with a native UUID type should handle
-    subtype 3 appropriately.</li>
-    <li><code>unsigned_byte(128)&mdash;unsigned_byte(255)</code> User defined subtypes. The binary data can be anything.</li>
+    <li>Array - The document for an array is a normal BSON document with integer values for the keys, starting with 0
+      and continuing sequentially. For example, the array ['red', 'blue'] would be encoded as the document {'0': 'red',
+      '1': 'blue'}. The keys must be in ascending numerical order.</li>
+    <li>UTC datetime - The int64 is UTC milliseconds since the Unix epoch.</li>
+    <li>Timestamp - Special internal type used by MongoDB replication and sharding. First 4 bytes are an increment,
+      second 4 are a timestamp.</li>
+    <li>Min key - Special type which compares lower than all other possible BSON element values.</li>
+    <li>Max key - Special type which compares higher than all other possible BSON element values.</li>
+    <li>Generic binary subtype - This is the most commonly used binary subtype and should be the 'default' for drivers
+      and tools.</li>
+    <li>The BSON "binary" or "BinData" datatype is used to represent
+      arrays of bytes. It is somewhat analogous to the Java notion of a
+      ByteArray. BSON binary values have a <em>subtype</em>. This is used to
+      indicate what kind of data is in the byte array. Subtypes from 0 to
+      127 are predefined or reserved. Subtypes from 128 to 255 are
+      user-defined.</li>
+    <ul>
+      <li><code>unsigned_byte(2)</code> Binary (Old) - This used to be the default
+        subtype, but was deprecated in favor of subtype 0.
+        Drivers and tools should be sure to handle subtype 2
+        appropriately. The structure of the binary data (the byte* array in
+        the binary non-terminal) must be an int32 followed by a (byte*). The
+        int32 is the number of bytes in the repetition.</li>
+      <li><code>unsigned_byte(3)</code> UUID (Old) - This used to be the UUID subtype,
+        but was deprecated in favor of subtype 4. Drivers
+        and tools for languages with a native UUID type should handle
+        subtype 3 appropriately.</li>
+      <li><code>unsigned_byte(128)&mdash;unsigned_byte(255)</code> User defined subtypes. The binary data can be
+        anything.</li>
+    </ul>
+    <li>Code with scope - <em>Deprecated.</em> The int32 is the length in bytes of the entire code_w_s value. The string
+      is JavaScript code. The document is a mapping from identifiers to values, representing the scope in which the
+      string should be evaluated.</li>
   </ul>
-  </li>
-  <li>Code with scope - <em>Deprecated.</em> The int32 is the length in bytes of the entire code_w_s value. The string is JavaScript code. The document is a mapping from identifiers to values, representing the scope in which the string should be evaluated.</li>
-</ul>
 
-<script type="text/javascript">
-  var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-  document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-</script>
-<script type="text/javascript">
-  try {
-  var pageTracker = _gat._getTracker("UA-7301842-4");
-  pageTracker._trackPageview();
-  } catch(err) {}
-</script>
+  <script type="text/javascript">
+    var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+    document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+  </script>
+  <script type="text/javascript">
+    try {
+      var pageTracker = _gat._getTracker("UA-7301842-4");
+      pageTracker._trackPageview();
+    } catch (err) { }
+  </script>
 </body>
+
 </html>


### PR DESCRIPTION
Adds some detail about BSON Subtype 7 - Compressed column. Content written by @henrikedin and slightly edited for grmamar/format.

[JIRA](https://jira.mongodb.org/browse/DOCS-15103)
[STAGING](https://raw.githack.com/mongodb/bsonspec.org/e275dc878a11bd337b16e1dbd0c7f14c63a81f30/spec.html)